### PR TITLE
Correctly detect lack of /bin/tar

### DIFF
--- a/lib/Archive/Extract.pm
+++ b/lib/Archive/Extract.pm
@@ -654,7 +654,7 @@ sub have_old_bunzip2 {
         ### check for /bin/tar ###
         ### check for /bin/gzip if we need it ###
         ### if any of the binaries are not available, return NA
-        {   my $diag =  not $self->bin_tar ?
+        {   my $diag =  !$self->bin_tar ?
                             loc("No '%1' program found", '/bin/tar') :
                         $self->is_tgz && !$self->bin_gzip ?
                             loc("No '%1' program found", '/bin/gzip') :


### PR DESCRIPTION
The higher-precedence not was applying to the expression as a whole,
rather than the first component.

This was causing breakage when using $PREFER_BIN on a system without a tar
command (such as Windows typically is), such as in the installer for
Alien::wxWidgets.

The high-precedence first meant that the check for the tar command was
passing when it should fail, and second that a later failing check (for
example when gzip also isn't found) had its error message inverted to the
empty string.
