### PR TITLE
Correctly compare version string for Archive::Tar

### DIFF
--- a/lib/Archive/Extract.pm
+++ b/lib/Archive/Extract.pm
@@ -815,8 +815,11 @@ sub _untar_at {
     ### if A::T's version is 0.99 or higher
     if( $self->is_tgz ) {
         my $use_list = { 'Compress::Zlib' => '0.0' };
+        {
+           local $@;
            $use_list->{ 'IO::Zlib' } = '0.0'
-                if $Archive::Tar::VERSION >= '0.99';
+                if eval { Archive::Tar->VERSION('0.99'); 1 };
+        }
 
         unless( can_load( modules => $use_list ) ) {
             my $which = join '/', sort keys %$use_list;


### PR DESCRIPTION
Checking Perl module versions numerically is incorrect, as they may be version tuples or contain underscores, the VERSION method will handle these cases.

Ref: https://rt.perl.org/Public/Bug/Display.html?id=131697